### PR TITLE
feat(ethereum): add Prague upgrade

### DIFF
--- a/specifications/ethereum.json
+++ b/specifications/ethereum.json
@@ -733,6 +733,49 @@
           "url": "https://eips.ethereum.org/EIPS/eip-4788"
         }
       }
+    },
+    {
+      "metadata": {
+        "name": "prague",
+        "block": -1
+      },
+      "precompiles": {
+        "0x0b": {
+          "name": "BLS12_G1ADD",
+          "description": "Performs point addition in G1"
+        },
+        "0x0c": {
+          "name": "BLS12_G1MSM",
+          "description": "Performs multi-scalar-multiplication in G1"
+        },
+        "0x0d": {
+          "name": "BLS12_G2ADD",
+          "description": "Performs point addition in G2"
+        },
+        "0x0e": {
+          "name": "BLS12_G2MSM",
+          "description": "Performs multi-scalar-multiplication in G2"
+        },
+        "0x0f": {
+          "name": "BLS12_PAIRING_CHECK",
+          "description": "Performs a pairing operations between a set of pairs of (G1, G2) points"
+        },
+        "0x10": {
+          "name": "BLS12_MAP_FP_TO_G1",
+          "description": "Maps base field element into the G1 point"
+        },
+        "0x11": {
+          "name": "BLS12_MAP_FP2_TO_G2",
+          "description": "Maps extension field element into the G2 point"
+        }
+      },
+      "system_contracts": {
+        "0x000f3df6d732807ef1319fb7b8bb8522d0beac02": {
+          "name": "HistoryStorage",
+          "description": "Returns the block hash associated with a given block number",
+          "url": "https://eips.ethereum.org/EIPS/eip-2935"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Pectra is set to be activated on May 7. It adds BLS precompiles and a History Storage system contract